### PR TITLE
Miscellaneous cleanups

### DIFF
--- a/src/emoji_label.vala
+++ b/src/emoji_label.vala
@@ -27,7 +27,7 @@ namespace Mingle {
             this.code_point_str = code_point_str;
             this.emoji = code_point_str_to_emoji(code_point_str);
             this.child = new Gtk.Label(this.emoji) {
-                css_classes = { "emoji", "card", "title-1" },
+                css_classes = { "emoji", "title-1" },
                 vexpand = true,
                 hexpand = true,
                 width_request = 50,

--- a/src/mingle.gresource.xml
+++ b/src/mingle.gresource.xml
@@ -4,7 +4,7 @@
     <file preprocess="xml-stripblanks">window.ui</file>
     <file preprocess="xml-stripblanks">gtk/help-overlay.ui</file>
     <file>style.css</file>
-    <file>metadata.json</file>
+    <file preprocess="json-stripblanks">metadata.json</file>
   </gresource>
 </gresources>
 

--- a/src/window.ui
+++ b/src/window.ui
@@ -40,21 +40,22 @@
 						<property name="content">
 							<object class="GtkCenterBox">
 								<property name="shrink-center-last">true</property>
-								<property name="margin-top">4</property>
-								<property name="margin-bottom">4</property>
-								<property name="margin-start">4</property>
-								<property name="margin-end">4</property>
 								<child type="start">
-									<object class="GtkScrolledWindow">
+									<object class="GtkScrolledWindow" id="left_scrolled_window">
 										<property name="propagate-natural-height">true</property>
-									  <property name="hexpand">true</property>
+										<property name="vadjustment" bind-source="right_scrolled_window" bind-property="vadjustment" bind-flags="sync-create|bidirectional"/>
+										<property name="hexpand">true</property>
 										<property name="has-frame">false</property>
 										<property name="window-placement">GTK_CORNER_TOP_RIGHT</property>
 										<child>
 											<object class="GtkFlowBox" id="left_emojis_flow_box">
+												<property name="margin-start">12</property>
+												<property name="margin-end">12</property>
+												<property name="margin-top">12</property>
+												<property name="margin-bottom">12</property>
 												<property name="orientation">0</property>
-												<property name="row-spacing">6</property>
-												<property name="column-spacing">6</property>
+												<property name="row-spacing">12</property>
+												<property name="column-spacing">12</property>
 												<property name="homogeneous">true</property>
 												<property name="max-children-per-line">6</property>
 												<property name="min-children-per-line">1</property>
@@ -78,6 +79,10 @@
 												<property name="has-frame">false</property>
 												<child>
 													<object class="GtkFlowBox" id="combined_emojis_flow_box">
+														<property name="margin-start">6</property>
+														<property name="margin-end">6</property>
+														<property name="margin-top">6</property>
+														<property name="margin-bottom">6</property>
 														<property name="orientation">0</property>
 														<property name="row-spacing">0</property>
 														<property name="column-spacing">6</property>
@@ -97,15 +102,20 @@
 									</object>
 								</child>
 								<child type="end">
-									<object class="GtkScrolledWindow">
+									<object class="GtkScrolledWindow" id="right_scrolled_window">
 										<property name="propagate-natural-height">true</property>
-									  <property name="hexpand">true</property>
+										<property name="vadjustment" bind-source="left_scrolled_window" bind-property="vadjustment" bind-flags="sync-create|bidirectional"/>
+										<property name="hexpand">true</property>
 										<property name="has-frame">false</property>
 										<child>
 											<object class="GtkFlowBox" id="right_emojis_flow_box">
+												<property name="margin-start">12</property>
+												<property name="margin-end">12</property>
+												<property name="margin-top">12</property>
+												<property name="margin-bottom">12</property>
 												<property name="orientation">0</property>
-												<property name="row-spacing">6</property>
-												<property name="column-spacing">6</property>
+												<property name="row-spacing">12</property>
+												<property name="column-spacing">12</property>
 												<property name="homogeneous">true</property>
 												<property name="max-children-per-line">6</property>
 												<property name="min-children-per-line">1</property>

--- a/src/window.vala
+++ b/src/window.vala
@@ -94,6 +94,7 @@ namespace Mingle {
         private void add_emoji_to_flowbox(string emoji, Gtk.FlowBox flowbox) {
             var item = new Mingle.EmojiLabel (emoji) {};
             flowbox.append (item);
+            item.get_parent ().add_css_class ("card");
         }
 
         private Json.Array get_combinations_by_emoji_code(string emoji_code) {


### PR DESCRIPTION
Changes:

- Apply the `card` style class to the FlowboxChild instead of the Label to avoid it looking weird on selection
- Strip whitespace from metadata.json when compiling to gresource
- Adjusted margins
- Made the two ScrolledWindows on the side scroll together. This is to make selection easier, so you don't have to find an emoji again on the other side if you already found it on the one you're looking at.
- Fixed a gap appearing around the ScrolledWindows

![Screenshot from 2023-11-11 20-06-58](https://github.com/halfmexican/mingle/assets/93832451/b3c9f8aa-a3d8-433a-885f-86af8648b8a7)
