### PR TITLE
Add keywords to desktop entry for easier searching

### DIFF
--- a/data/io.github.halfmexican.Mingle.desktop.in
+++ b/data/io.github.halfmexican.Mingle.desktop.in
@@ -5,4 +5,5 @@ Icon=io.github.halfmexican.Mingle
 Terminal=false
 Type=Application
 Categories=Utility;GTK;
+Keywords=emoji;mix;Google;kitchen;Noto;
 StartupNotify=true


### PR DESCRIPTION
Hello! I found it a bit odd that I couldn't find the app when searching "emoji", so I added a "Keywords" entry and added the word to it, I also added some other words to be sure.  
Let me know if they're fine or they need any changes!

Thanks for the super fun app btw <sub><img height="20px" alt="dramatic mind blown emoji" src="https://github.com/halfmexican/mingle/assets/56311398/a1d92d1f-e7fe-4b7a-81b1-f7984559c4b2"></sub>

(oh, right, and here's the [Freedesktop spec](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html) if you're curious, at the "Standard Keys" paragraph)