### PR TITLE
Add QuazarOmega as developer

### DIFF
--- a/src/application.vala
+++ b/src/application.vala
@@ -52,7 +52,11 @@ namespace Mingle {
         }
 
         private void on_about_action () {
-            string[] developers = { "José Hunter https://github.com/halfmexican", "kramo https://kramo.page" };
+            string[] developers = {
+                "José Hunter https://github.com/halfmexican",
+                "kramo https://kramo.page",
+                "QuazarOmega https://github.com/quazar-omega"
+            };
             var about = new Adw.AboutDialog () {
                 application_name = "mingle",
                 application_icon = "io.github.halfmexican.Mingle",


### PR DESCRIPTION
Hello again, following up from #19.

I changed the formatting to avoid making the line huge.  
But I'm not sure I should add myself to "developers", I mean I haven't contributed any Vala code (well, except this here lol), maybe a more generic acknowledgement is more fitting? From [AboutDialog docs](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.AboutDialog.html#credits-and-acknowledgements) there's this function `adw_about_dialog_add_acknowledgement_section()` to do that, I may just be overthinking tho

Note: I haven't tested the app with my changes, so I'll wait to make this an actual pull request once I did, or if you tell me it's fine like this