### PR TITLE
Various fixes, 10x installation size reduction

### DIFF
--- a/io.github.halfmexican.Mingle.json
+++ b/io.github.halfmexican.Mingle.json
@@ -3,9 +3,6 @@
     "runtime" : "org.gnome.Platform",
     "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
-    "sdk-extensions" : [
-        "org.freedesktop.Sdk.Extension.vala"
-    ],   
     "command" : "mingle",
     "finish-args" : [
         "--share=network",
@@ -14,10 +11,6 @@
         "--device=dri",
         "--socket=wayland"
     ],
-    "build-options" : {
-        "append-path" : "/usr/lib/sdk/vala/bin",
-        "prepend-ld-library-path" : "/usr/lib/sdk/vala/lib"
-    },
     "cleanup" : [
         "/include",
         "/lib/pkgconfig",
@@ -49,9 +42,11 @@
             "buildsystem" : "meson",
             "sources" : [
                 {
-                    "type" : "git",
-                    "url" : "https://github.com/halfmexican/mingle.git",
-                    "branch": "main"
+                    "type" : "dir",
+                    "path" : ".",
+                    "ignore": [
+                        ".git"
+                    ]
                 }
             ]
         }

--- a/src/combined_emoji.vala
+++ b/src/combined_emoji.vala
@@ -18,14 +18,13 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-using Adw, Gtk, Gdk, Soup;
 namespace Mingle {
     public class CombinedEmoji : Gtk.Button {
-        private Texture _texture;
-        private Texture _scaled_texture;
+        private Gdk.Texture _texture;
+        private Gdk.Texture _scaled_texture;
         private GLib.Settings settings = new GLib.Settings ("io.github.halfmexican.Mingle");
         private EmojiCombination combined_emoji;
-        public Revealer revealer;
+        public Gtk.Revealer revealer;
         public signal void copied ();
 
         public async CombinedEmoji (EmojiCombination combination_struct, Gtk.RevealerTransitionType transition, out bool image_loaded) {

--- a/src/emoji_data_manager.vala
+++ b/src/emoji_data_manager.vala
@@ -18,19 +18,17 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-using Json, Soup, Gee;
-
 namespace Mingle {
     public class EmojiDataManager {
         private Json.Object data_object;
         private Json.Array supported_emojis;
-        public HashSet<string> added_combinations;
+        public Gee.HashSet<string> added_combinations;
         private Gee.HashMap<string, EmojiData?> emoji_data_map;
 
         public async EmojiDataManager () {
             supported_emojis = populate_supported_emojis_array ();
             emoji_data_map = new Gee.HashMap<string, EmojiData?> ();
-            added_combinations = new HashSet<string> ();
+            added_combinations = new Gee.HashSet<string> ();
         }
 
         private Json.Array populate_supported_emojis_array () {
@@ -58,7 +56,7 @@ namespace Mingle {
             if (supported_emojis == null)
                 supported_emojis = populate_supported_emojis_array ();
 
-            ArrayForeach array_foreach_func = (array, index_, element_node) => {
+            Json.ArrayForeach array_foreach_func = (array, index_, element_node) => {
                 if (element_node.get_node_type () == Json.NodeType.VALUE) {
                     string emoji_code = element_node.get_string ();
                     add_emoji_to_flowbox (emoji_code, flowbox);

--- a/src/emoji_data_manager.vala
+++ b/src/emoji_data_manager.vala
@@ -35,19 +35,13 @@ namespace Mingle {
 
         private Json.Array populate_supported_emojis_array () {
             // Returns the known_supported_array by parsing metadata.json
-            string file_contents;
-            size_t length;
-
             try {
                 var input_stream = GLib.resources_open_stream ("/io/github/halfmexican/Mingle/emoji_data/metadata.json", GLib.ResourceLookupFlags.NONE);
-                var data_stream = new GLib.DataInputStream (input_stream);
-                file_contents = data_stream.read_upto ("", -1, out length);
 
                 Json.Parser parser = new Json.Parser ();
-                parser.load_from_data (file_contents, -1);
+                parser.load_from_stream (input_stream, null);
 
                 input_stream.close (null);
-                data_stream.close (null);
 
                 Json.Object root_object = parser.get_root ().get_object ();
                 data_object = root_object.get_object_member ("data");

--- a/src/emoji_label.vala
+++ b/src/emoji_label.vala
@@ -18,7 +18,6 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-using Gtk;
 namespace Mingle {
     public class EmojiLabel : Adw.Bin {
         private string emoji;

--- a/src/emoji_structs.vala
+++ b/src/emoji_structs.vala
@@ -1,5 +1,3 @@
-using Gtk, Mingle;
-
 namespace Mingle {
 
     public struct EmojiData {

--- a/src/mingle.gresource.xml
+++ b/src/mingle.gresource.xml
@@ -5,7 +5,7 @@
     <file preprocess="xml-stripblanks">gtk/help-overlay.ui</file>
     <file preprocess="xml-stripblanks">gtk/prefs.ui</file>
     <file preprocess="xml-stripblanks">gtk/style-switcher.ui</file>
-    <file preprocess="json-stripblanks">emoji_data/metadata.json</file>
+    <file preprocess="json-stripblanks" compressed="true">emoji_data/metadata.json</file>
     <file>style.css</file>
   </gresource>
 </gresources>

--- a/src/prefs.vala
+++ b/src/prefs.vala
@@ -18,7 +18,6 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-using Gtk, Adw, GLib;
 namespace Mingle {
     [GtkTemplate (ui = "/io/github/halfmexican/Mingle/gtk/prefs.ui")]
     public class PrefsDialog : Adw.PreferencesDialog {

--- a/src/style_switcher.vala
+++ b/src/style_switcher.vala
@@ -17,7 +17,6 @@
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-using Adw;
 
 namespace Mingle {
     [GtkTemplate (ui = "/io/github/halfmexican/Mingle/gtk/style-switcher.ui")]

--- a/src/window.vala
+++ b/src/window.vala
@@ -18,26 +18,25 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-using Gtk, Adw, Json, Soup, Gee;
 namespace Mingle {
     [GtkTemplate (ui = "/io/github/halfmexican/Mingle/gtk/window.ui")]
     public class Window : Adw.ApplicationWindow {
         // UI
-        [GtkChild] private unowned Stack window_stack;
-        [GtkChild] private unowned FlowBox left_emojis_flow_box;
-        [GtkChild] private unowned FlowBox right_emojis_flow_box;
-        [GtkChild] private unowned FlowBox combined_emojis_flow_box;
-        [GtkChild] private unowned ScrolledWindow combined_scrolled_window;
-        [GtkChild] private unowned ScrolledWindow left_scrolled_window;
-        [GtkChild] private unowned ScrolledWindow right_scrolled_window;
-        [GtkChild] private unowned ToastOverlay toast_overlay;
-        [GtkChild] private unowned PopoverMenu popover_menu;
-        [GtkChild] private unowned ToolbarView toolbar_view;
-        [GtkChild] private unowned Button randomize_button;
-        [GtkChild] private unowned ToggleButton search_button;
-        [GtkChild] private unowned Breakpoint breakpoint;
-        [GtkChild] private unowned SearchBar search_bar;
-        [GtkChild] private unowned SearchEntry search_entry;
+        [GtkChild] private unowned Gtk.Stack window_stack;
+        [GtkChild] private unowned Gtk.FlowBox left_emojis_flow_box;
+        [GtkChild] private unowned Gtk.FlowBox right_emojis_flow_box;
+        [GtkChild] private unowned Gtk.FlowBox combined_emojis_flow_box;
+        [GtkChild] private unowned Gtk.ScrolledWindow combined_scrolled_window;
+        [GtkChild] private unowned Gtk.ScrolledWindow left_scrolled_window;
+        [GtkChild] private unowned Gtk.ScrolledWindow right_scrolled_window;
+        [GtkChild] private unowned Adw.ToastOverlay toast_overlay;
+        [GtkChild] private unowned Gtk.PopoverMenu popover_menu;
+        [GtkChild] private unowned Adw.ToolbarView toolbar_view;
+        [GtkChild] private unowned Gtk.Button randomize_button;
+        [GtkChild] private unowned Gtk.ToggleButton search_button;
+        [GtkChild] private unowned Adw.Breakpoint breakpoint;
+        [GtkChild] private unowned Gtk.SearchBar search_bar;
+        [GtkChild] private unowned Gtk.SearchEntry search_entry;
         private GLib.Binding? scroll_binding;
 
         // Class variables
@@ -81,7 +80,7 @@ namespace Mingle {
             this.settings.changed.connect (handle_pref_change);
             this.bind_property ("is-loading", left_emojis_flow_box, "sensitive", BindingFlags.INVERT_BOOLEAN);
             combined_scrolled_window.edge_overshot.connect (on_edge_overshot); // Handles loading more emojis on scroll
-            right_scrolled_window.window_placement = CornerType.TOP_RIGHT;
+            right_scrolled_window.window_placement = TOP_RIGHT;
             left_emojis_flow_box.set_filter_func (filter_emojis);
             search_entry.search_changed.connect (() => {
                 left_emojis_flow_box.invalidate_filter ();
@@ -131,8 +130,8 @@ namespace Mingle {
         }
 
         private void bind_scroll_adjustments () {
-            Adjustment left_adjustment = left_scrolled_window.get_vadjustment ();
-            Adjustment right_adjustment = right_scrolled_window.get_vadjustment ();
+            Gtk.Adjustment left_adjustment = left_scrolled_window.get_vadjustment ();
+            Gtk.Adjustment right_adjustment = right_scrolled_window.get_vadjustment ();
             scroll_binding = left_adjustment.bind_property (
                                                             "value",
                                                             right_adjustment,
@@ -159,7 +158,7 @@ namespace Mingle {
             }
         }
 
-        private bool filter_emojis (FlowBoxChild child) {
+        private bool filter_emojis (Gtk.FlowBoxChild child) {
             Mingle.EmojiLabel emoji_label = (Mingle.EmojiLabel) child.get_child ();
             string search_text = search_entry.text.up ();
             foreach (string keyword in emoji_label.keywords) {
@@ -189,7 +188,7 @@ namespace Mingle {
             });
         }
 
-        private void connect_flow_box_signals (FlowBox flowbox, EmojiActionDelegate handler) {
+        private void connect_flow_box_signals (Gtk.FlowBox flowbox, EmojiActionDelegate handler) {
             flowbox.child_activated.connect ((item) => {
                 Mingle.EmojiLabel emoji_label = (Mingle.EmojiLabel) item.child;
                 handler (emoji_label);
@@ -238,7 +237,7 @@ namespace Mingle {
             update_window_title ();
         }
 
-        private async void prepend_combined_emoji (string left_emoji_code, string right_emoji_code, RevealerTransitionType transition) {
+        private async void prepend_combined_emoji (string left_emoji_code, string right_emoji_code, Gtk.RevealerTransitionType transition) {
             string combination_key = left_emoji_code + right_emoji_code;
 
             bool load_success;
@@ -261,7 +260,7 @@ namespace Mingle {
             }
         }
 
-        private async void append_combined_emoji (string left_emoji_code, string right_emoji_code, RevealerTransitionType transition) {
+        private async void append_combined_emoji (string left_emoji_code, string right_emoji_code, Gtk.RevealerTransitionType transition) {
             string combination_key = left_emoji_code + right_emoji_code;
             if (emoji_manager.is_combination_added (combination_key)) {
                 return;
@@ -381,30 +380,30 @@ namespace Mingle {
             }
         }
 
-        private RevealerTransitionType create_combined_emoji_revealer_transition (bool direction) {
+        private Gtk.RevealerTransitionType create_combined_emoji_revealer_transition (bool direction) {
             // Returns a RevealerTranstionType based on user settings
             // 0 is left, 1 is right
             switch (this.revealer_transition) {
             case Transition.NONE:
-                return RevealerTransitionType.NONE;
+                return Gtk.RevealerTransitionType.NONE;
             case Transition.CROSSFADE:
-                return RevealerTransitionType.CROSSFADE;
+                return Gtk.RevealerTransitionType.CROSSFADE;
             case Transition.SLIDE:
                 if (direction)
-                    return RevealerTransitionType.SLIDE_RIGHT;
-                return RevealerTransitionType.SLIDE_LEFT;
+                    return Gtk.RevealerTransitionType.SLIDE_RIGHT;
+                return Gtk.RevealerTransitionType.SLIDE_LEFT;
             case Transition.SWING:
                 if (direction)
-                    return RevealerTransitionType.SWING_RIGHT;
-                return RevealerTransitionType.SWING_LEFT;
+                    return Gtk.RevealerTransitionType.SWING_RIGHT;
+                return Gtk.RevealerTransitionType.SWING_LEFT;
             case Transition.SWING_UP:
-                return RevealerTransitionType.SWING_UP;
+                return Gtk.RevealerTransitionType.SWING_UP;
             default:
-                return RevealerTransitionType.CROSSFADE;
+                return Gtk.RevealerTransitionType.CROSSFADE;
             }
         }
 
-        private void set_child_sensitivity (FlowBoxChild child) {
+        private void set_child_sensitivity (Gtk.FlowBoxChild child) {
             Mingle.EmojiLabel emoji_label = (Mingle.EmojiLabel) child.get_child ();
             string right_emoji_code = emoji_label.codepoint;
 
@@ -414,7 +413,7 @@ namespace Mingle {
         }
 
         private void update_sensitivity_of_right_flowbox () {
-            FlowBoxChild child = right_emojis_flow_box.get_child_at_index (0);
+            Gtk.FlowBoxChild child = right_emojis_flow_box.get_child_at_index (0);
             int index = 0;
 
             while (child != null) {
@@ -460,9 +459,9 @@ namespace Mingle {
             }
         }
 
-        private void on_edge_overshot (PositionType pos_type) {
+        private void on_edge_overshot (Gtk.PositionType pos_type) {
             // Loads more emojis when we scroll
-            if (pos_type != PositionType.BOTTOM) {
+            if (pos_type != BOTTOM) {
                 return; // We are only interested in the bottom edge
             }
 


### PR DESCRIPTION
I felt a degree of responsibility to fix at least some of this upon stumbling across it...

* Make the Flatpak file build from local source since that's what you want during development and CI
* Don't include the Vala SDK extension since Vala is already included in the GNOME runtime
* Reduce the installation size by about 10x (84MB -> 8 MB) by utilizing GLib resources compression for the emoji metadata file
* Use the included method for loading JSON data from stream, avoiding loading the entire source file into memory at once
* Eliminate the `using` statement and use namespaces directly - thankfully, this one was already mostly done

My next suggestion would be to avoid storing the JSON data (`data_object` and `supported_emojis`) in its original form long-term and instead pack it on loading into a more specific data structure to reduce memory consumption. I'm not down for this level of rewrite myself right now. Also, YAML is IMO much nicer for Flatpak manifests, but that's personal, and thus I haven't touched that.